### PR TITLE
Require R 4.0

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -48,7 +48,7 @@ jobs:
         config:
           - {os: windows-latest, r: 'release'}
           - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-20.04, r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          - {os: ubuntu-20.04, r: '4.0', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-latest, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
           - {os: ubuntu-latest, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
@@ -78,45 +78,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y texlive-latex-base libglpk-dev texlive-fonts-recommended
-        
-      - name: Set up R dependencies (R 3.6)
-        if: matrix.config.r == '3.6'
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          # Guesses: Umatrix; uwot
-          extra-packages: |
-            purrr@1.0.2
-            bench@1.1.3
-            hardhat@1.4.0
-            dotCall64@1.1-1
-            spam@2.10-0
-            waldo@0.5.3
-            testthat@3.2.1
-            vdiffr@1.0.7
-            cpp11@0.5.0
-            httr2@1.0.1
-            downlit@0.4.3
-            pkgdown@2.0.9
-            profvis@0.3.8
-            gtable@0.3.5
-            Matrix@1.6-5
-            RcppAnnoy@0.0.14
-            RcppGSL@0.3.8
-            RcppZiggurat@0.1.5
-            uwot@0.1.8
-            Umatrix@3.3
-            hypervolume@3.1.1
-            actuar@2.3-3
-            evaluate@0.23
-            fastICA@1.2-1
-            FNN@1.1.3.2
-            knitr@1.45
-            phangorn@2.7.1
-            Rfast@1.9.8
-            rjson@0.2.20
-            XML@3.99-0.3
-          needs: |
-            check
 
       - name: Set up R dependencies (Windows)
         if: runner.os == 'Windows'
@@ -131,7 +92,7 @@ jobs:
             coverage
             
       - name: Set up R dependencies (Non-Windows)
-        if: runner.os != 'Windows' && matrix.config.r != '3.6'
+        if: runner.os != 'Windows'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TreeDist
 Type: Package
 Title: Calculate and Map Distances Between Phylogenetic Trees
-Version: 2.9.2
+Version: 2.9.2.9000
 Authors@R: c(person("Martin R.", "Smith",
                     email = "martin.smith@durham.ac.uk", 
                     role = c("aut", "cre", "cph", "prg"), 
@@ -39,7 +39,7 @@ URL: https://ms609.github.io/TreeDist/, https://github.com/ms609/TreeDist/
 BugReports: https://github.com/ms609/TreeDist/issues/
 Additional_repositories: https://ms609.github.io/packages/
 Depends: 
-  R (>= 3.4.0),
+  R (>= 4.0),
   stats,
 Imports: 
   ape (>= 5.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# TreeDist 2.9.2.9000 (2025-02)
+
+- Require R4.0.
+
+
 # TreeDist 2.9.2 (2025-01-11)
 
 - Fix crash when calculating NNI distance for large trees.

--- a/R/tree_distance_utilities.R
+++ b/R/tree_distance_utilities.R
@@ -476,10 +476,7 @@ NormalizeInfo <- function(unnormalized, tree1, tree2, InfoInTree,
   CombineInfo <- function(tree1Info, tree2Info, Combiner = Combine,
                           pairwise = FALSE) {
     if (length(tree1Info) == 1 || length(tree2Info) == 1 || pairwise) {
-      # TODO When requriring R4.0, remove match.fun - which is now part of
-      # .mapply
-      unlist(.mapply(match.fun(Combiner),
-                     dots = list(tree1Info, tree2Info), NULL))
+      unlist(.mapply(Combiner, dots = list(tree1Info, tree2Info), NULL))
     } else {
       ret <- outer(tree1Info, tree2Info, Combiner)
       if (inherits(unnormalized, "dist")) ret[lower.tri(ret)] else ret


### PR DESCRIPTION
No-one's downloaded this package to R4.0 for [six months].

This simplifies maintenance, and allows the removal of `match.fun` from `.mapply()`.
