### PR TITLE
Prepare for large-tree support

### DIFF
--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - '**valgrind**'
     paths:
       - '.github/workflows/memcheck.yml'
       - 'src/**'
@@ -30,7 +31,8 @@ name: mem-check
 jobs:
   mem-check:
     runs-on: ubuntu-24.04
-    name: valgrind ${{ matrix.config.test }}, ubuntu, R release
+
+    name: valgrind ${{ matrix.config.test }}
 
     strategy:
       fail-fast: false
@@ -39,12 +41,13 @@ jobs:
           - {test: 'tests'}
           - {test: 'examples'}
           - {test: 'vignettes'}
-          
+
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       _R_CHECK_FORCE_SUGGESTS_: false
       RSPM: https://packagemanager.rstudio.com/cran/__linux__/noble/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      ASAN_OPTIONS: verify_asan_link_order=0
 
     steps:
       - uses: ms609/actions/memcheck@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TreeDist
 Title: Calculate and Map Distances Between Phylogenetic Trees
-Version: 2.13.0.9002
+Version: 2.13.0.9003
 Authors@R: c(person("Martin R.", "Smith",
                     email = "martin.smith@durham.ac.uk", 
                     role = c("aut", "cre", "cph", "prg"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# TreeDist 2.13.0.9002
+# TreeDist 2.13.0.9003
 
 ## New features
 
@@ -16,6 +16,13 @@
 - LAP (Jonker–Volgenant linear assignment) and MCI (Mutual Clustering
   Information) C++ implementations are now exposed via `inst/include/TreeDist/`
   headers, allowing downstream packages to use `LinkingTo: TreeDist`.
+
+## Internals
+
+- Stack-allocated split buffers replaced with dynamically-sized vectors,
+  removing a hard dependency on the compile-time `SL_MAX_SPLITS` constant.
+  TreeDist now supports trees of any size permitted by TreeTools, including
+  the forthcoming increase to 32 768 tips.
 
 ## Performance
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,8 +21,7 @@
 
 - Stack-allocated split buffers replaced with dynamically-sized vectors,
   removing a hard dependency on the compile-time `SL_MAX_SPLITS` constant.
-  TreeDist now supports trees of any size permitted by TreeTools, including
-  the forthcoming increase to 32 768 tips.
+  TreeDist now supports trees of any size permitted by TreeTools.
 
 ## Performance
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -275,6 +275,10 @@ cpp_mci_impl_score <- function(x, y, n_tips) {
     .Call(`_TreeDist_cpp_mci_impl_score`, x, y, n_tips)
 }
 
+cpp_sl_max_tips <- function() {
+    .Call(`_TreeDist_cpp_sl_max_tips`)
+}
+
 cpp_robinson_foulds_distance <- function(x, y, nTip) {
     .Call(`_TreeDist_cpp_robinson_foulds_distance`, x, y, nTip)
 }

--- a/R/transfer_consensus.R
+++ b/R/transfer_consensus.R
@@ -65,7 +65,7 @@ TransferConsensus <- function(trees,
   if (nTip < 4L) {
     return(StarTree(tipLabels))
   }
-  if (nTip > 32767L) stop("This many tips are not (yet) supported.")
+  .CheckMaxTips(nTip)
 
   # Convert each tree to a raw split matrix (TreeTools C++ internally).
   # as.Splits() will error if a tree's tips don't match tipLabels.
@@ -114,7 +114,7 @@ tc_profile <- function(trees, scale = TRUE, greedy = "best",
   tipLabels <- TipLabels(trees[[1]])
   nTip <- length(tipLabels)
   if (nTip < 4L) stop("Need at least 4 tips for profiling.")
-  if (nTip > 32767L) stop("This many tips are not (yet) supported.")
+  .CheckMaxTips(nTip)
 
   splitsList <- lapply(trees, function(tr) unclass(as.Splits(tr, tipLabels)))
 

--- a/R/tree_distance.R
+++ b/R/tree_distance.R
@@ -149,7 +149,7 @@ GeneralizedRF <- function(splits1, splits2, nTip, PairScorer,
   }
   nTip <- length(tipLabels)
   if (nTip < 4) return(NULL) # nocov
-  if (nTip > 32767L) stop("This many tips are not (yet) supported.")
+  .CheckMaxTips(nTip)
   
   splits_list <- as.Splits(tree1, tipLabels = tipLabels)
   n_threads <- as.integer(getOption("mc.cores", 1L))
@@ -203,7 +203,7 @@ GeneralizedRF <- function(splits1, splits2, nTip, PairScorer,
   
   nTip <- length(tipLabels1)
   if (nTip < 4) return(NULL)
-  if (nTip > 32767L) stop("This many tips are not (yet) supported.")
+  .CheckMaxTips(nTip)
   
   splits1 <- as.Splits(tree1, tipLabels = tipLabels1)
   splits2 <- as.Splits(tree2, tipLabels = tipLabels1)  # Use tipLabels1 to ensure order consistency

--- a/R/tree_distance_transfer.R
+++ b/R/tree_distance_transfer.R
@@ -168,7 +168,7 @@ TransferDistSplits <- function(splits1, splits2,
   if (is.null(tipLabels)) return(NULL)
   nTip <- length(tipLabels)
   if (nTip < 4L) return(NULL)
-  if (nTip > 32767L) stop("This many tips are not (yet) supported.")
+  .CheckMaxTips(nTip)
   
   # Check all trees share same tip set
   allLabels <- TipLabels(tree1)
@@ -211,7 +211,7 @@ TransferDistSplits <- function(splits1, splits2,
   if (is.null(tipLabels)) return(NULL)
   nTip <- length(tipLabels)
   if (nTip < 4L) return(NULL)
-  if (nTip > 32767L) stop("This many tips are not (yet) supported.")
+  .CheckMaxTips(nTip)
   
   # Check all trees share same tip set
   allLabels1 <- TipLabels(trees1)

--- a/R/tree_distance_utilities.R
+++ b/R/tree_distance_utilities.R
@@ -1,3 +1,18 @@
+# Validate that nTip does not exceed the compiled SL_MAX_TIPS limit.
+# Called from every distance entry point before any C++ work.
+.CheckMaxTips <- function(nTip) {
+  if (!is.na(nTip) && nTip > .SL_MAX_TIPS) {
+    stop(
+      "Trees with ", nTip, " tips exceed the compiled limit of ",
+      .SL_MAX_TIPS, " tips.",
+      if (.SL_MAX_TIPS < 32768L)
+        "\nUpdate TreeTools and reinstall TreeDist to support more tips."
+      else "",
+      call. = FALSE
+    )
+  }
+}
+
 #' Wrapper for tree distance calculations
 #' 
 #' Calls tree distance functions from trees or lists of trees
@@ -132,9 +147,7 @@ CalculateTreeDistance <- function(Func, tree1, tree2 = NULL,
   # Fast paths: use OpenMP batch functions when all trees share the same tip
   # set and no R-level cluster has been configured.  Each branch mirrors the
   # generic path exactly but avoids per-pair R overhead.
-  if (!is.na(nTip) && nTip > 32767L) {
-    stop("This many tips are not (yet) supported.")
-  }
+  .CheckMaxTips(nTip)
   if (!is.na(nTip) && is.null(cluster)) {
     .n_threads <- as.integer(getOption("mc.cores", 1L))
     .batch_result <- if (identical(Func, MutualClusteringInfoSplits)) {
@@ -235,9 +248,7 @@ CalculateTreeDistance <- function(Func, tree1, tree2 = NULL,
 #' @importFrom stats setNames
 .SplitDistanceManyMany <- function(Func, splits1, splits2, 
                                    tipLabels, nTip = length(tipLabels), ...) {
-  if (!is.na(nTip) && nTip > 32767L) {
-    stop("This many tips are not (yet) supported.")
-  }
+  .CheckMaxTips(nTip)
   if (is.na(nTip)) {
     tipLabels <- union(unlist(tipLabels, use.names = FALSE),
                        unlist(TipLabels(splits2), use.names = FALSE))
@@ -408,9 +419,7 @@ CalculateTreeDistance <- function(Func, tree1, tree2 = NULL,
   if (ncol(x) != ncol(y)) {
     stop("Input splits must address same number of tips.")
   }
-  if (nTip > 32767L) {
-    stop("This many tips are not (yet) supported.")
-  }
+  .CheckMaxTips(nTip)
 }
 
 .CheckLabelsSame <- function(labelList) {

--- a/R/tree_distance_utilities.R
+++ b/R/tree_distance_utilities.R
@@ -2,14 +2,15 @@
 # Called from every distance entry point before any C++ work.
 .CheckMaxTips <- function(nTip) {
   if (!is.na(nTip) && nTip > .SL_MAX_TIPS) {
-    stop(
-      "Trees with ", nTip, " tips exceed the compiled limit of ",
-      .SL_MAX_TIPS, " tips.",
-      if (.SL_MAX_TIPS < 32768L)
-        "\nUpdate TreeTools and reinstall TreeDist to support more tips."
-      else "",
-      call. = FALSE
-    )
+    if (.SL_MAX_TIPS < 32704L) {
+      stop(
+        "Trees with ", nTip, " tips exceed the compiled limit of ",
+        .SL_MAX_TIPS, " tips.",
+          "\nUpdate TreeTools and reinstall TreeDist to support more tips."
+      )
+    }
+    stop("Trees with ", nTip, " tips are not yet supported (maximum ",
+         .SL_MAX_TIPS, ")")
   }
 }
 
@@ -27,14 +28,6 @@
 #' @importFrom utils combn
 #' @export
 # Keep in sync with C++ guard: min(SL_MAX_TIPS, int16_t::max()).
-.MaxSupportedTips <- 32767L
-
-.AssertNtipSupported <- function(nTip) {
-  if (!is.na(nTip) && nTip > .MaxSupportedTips) {
-    stop("This many tips are not (yet) supported.")
-  }
-}
-
 CalculateTreeDistance <- function(Func, tree1, tree2 = NULL,
                                   reportMatching = FALSE, ...) {
   supportedClasses <- c("phylo", "Splits")
@@ -346,7 +339,7 @@ CalculateTreeDistance <- function(Func, tree1, tree2 = NULL,
 #' @param checks Logical specifying whether to perform basic sanity checks to
 #' avoid crashes in C++.
 #' @keywords internal
-#' @seealso [`CalculateTreeDistance`]
+#' @seealso [`CalculateTreeDistance()`]
 #' @export
 .TreeDistance <- function(Func, tree1, tree2, checks = TRUE, ...) {
   single1 <- inherits(tree1, "phylo")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,9 @@
+.SL_MAX_TIPS <- NULL # populated in .onLoad
+
+.onLoad <- function(libname, pkgname) {
+  .SL_MAX_TIPS <<- cpp_sl_max_tips()
+}
+
 .onUnload <- function(libpath) {
   StopParallel(quietly = TRUE)
   library.dynam.unload("TreeDist", libpath)

--- a/man/dot-TreeDistance.Rd
+++ b/man/dot-TreeDistance.Rd
@@ -14,7 +14,7 @@ avoid crashes in C++.}
 Calculate distance between trees, or lists of trees
 }
 \seealso{
-\code{\link{CalculateTreeDistance}}
+\code{\link[=CalculateTreeDistance]{CalculateTreeDistance()}}
 }
 \author{
 \href{https://orcid.org/0000-0001-5660-1727}{Martin R. Smith}

--- a/memcheck/all.R
+++ b/memcheck/all.R
@@ -1,4 +1,0 @@
-devtools::load_all()
-devtools::run_examples()
-devtools::build_vignettes()
-devtools::test()

--- a/memcheck/tests.R
+++ b/memcheck/tests.R
@@ -1,5 +1,4 @@
-# Code to be run with  
-#   R -d "valgrind --tool=memcheck --leak-check=full" --vanilla < tests/thisfile.R
-# First build and install the package.
+# Code to be run with
+#   R -d "valgrind --tool=memcheck --leak-check=full --error-exitcode=1" --vanilla < memcheck/thisfile.R
 library("TreeDist")
 devtools::test()

--- a/memcheck/vignettes.R
+++ b/memcheck/vignettes.R
@@ -1,5 +1,3 @@
-# Code to be run with  
-#   R -d "valgrind --tool=memcheck --leak-check=full" --vanilla < tests/thisfile.R
-# First build and install the package.
-library("TreeDist")
-devtools::build_vignettes()
+# Code to be run with
+#   R -d "valgrind --tool=memcheck --leak-check=full --error-exitcode=1" --vanilla < memcheck/thisfile.R
+devtools::build_vignettes(install = FALSE)

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -636,6 +636,16 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// cpp_sl_max_tips
+int cpp_sl_max_tips();
+RcppExport SEXP _TreeDist_cpp_sl_max_tips() {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    rcpp_result_gen = Rcpp::wrap(cpp_sl_max_tips());
+    return rcpp_result_gen;
+END_RCPP
+}
 // cpp_robinson_foulds_distance
 List cpp_robinson_foulds_distance(const RawMatrix& x, const RawMatrix& y, const IntegerVector& nTip);
 RcppExport SEXP _TreeDist_cpp_robinson_foulds_distance(SEXP xSEXP, SEXP ySEXP, SEXP nTipSEXP) {
@@ -780,6 +790,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_TreeDist_cpp_transfer_dist_all_pairs", (DL_FUNC) &_TreeDist_cpp_transfer_dist_all_pairs, 4},
     {"_TreeDist_cpp_transfer_dist_cross_pairs", (DL_FUNC) &_TreeDist_cpp_transfer_dist_cross_pairs, 5},
     {"_TreeDist_cpp_mci_impl_score", (DL_FUNC) &_TreeDist_cpp_mci_impl_score, 3},
+    {"_TreeDist_cpp_sl_max_tips", (DL_FUNC) &_TreeDist_cpp_sl_max_tips, 0},
     {"_TreeDist_cpp_robinson_foulds_distance", (DL_FUNC) &_TreeDist_cpp_robinson_foulds_distance, 3},
     {"_TreeDist_cpp_robinson_foulds_info", (DL_FUNC) &_TreeDist_cpp_robinson_foulds_info, 3},
     {"_TreeDist_cpp_matching_split_distance", (DL_FUNC) &_TreeDist_cpp_matching_split_distance, 3},

--- a/src/pairwise_distances.cpp
+++ b/src/pairwise_distances.cpp
@@ -305,6 +305,7 @@ NumericVector cpp_mutual_clustering_all_pairs(
     const int   n_tip,
     const int   n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   if (N < 2) return NumericVector(0);
 
@@ -397,6 +398,7 @@ NumericVector cpp_rf_info_all_pairs(
     const int   n_tip,
     const int   n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   if (N < 2) return NumericVector(0);
   const int n_pairs = N * (N - 1) / 2;
@@ -516,6 +518,7 @@ NumericVector cpp_msd_all_pairs(
     const int   n_tip,
     const int   n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   if (N < 2) return NumericVector(0);
   const int n_pairs = N * (N - 1) / 2;
@@ -618,6 +621,7 @@ NumericVector cpp_msi_all_pairs(
     const int   n_tip,
     const int   n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   if (N < 2) return NumericVector(0);
   const int n_pairs = N * (N - 1) / 2;
@@ -710,6 +714,7 @@ NumericVector cpp_shared_phylo_all_pairs(
     const int   n_tip,
     const int   n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   if (N < 2) return NumericVector(0);
   const int n_pairs = N * (N - 1) / 2;
@@ -875,6 +880,7 @@ NumericVector cpp_jaccard_all_pairs(
     const bool    allow_conflict = true,
     const int     n_threads     = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   if (N < 2) return NumericVector(0);
   const int n_pairs = N * (N - 1) / 2;
@@ -944,6 +950,7 @@ NumericMatrix cpp_mutual_clustering_cross_pairs(
     const List& splits_a, const List& splits_b,
     const int n_tip, const int n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int nA = splits_a.size();
   const int nB = splits_b.size();
   if (nA == 0 || nB == 0) return NumericMatrix(nA, nB);
@@ -987,6 +994,7 @@ NumericMatrix cpp_rf_info_cross_pairs(
     const List& splits_a, const List& splits_b,
     const int n_tip, const int n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int nA = splits_a.size();
   const int nB = splits_b.size();
   if (nA == 0 || nB == 0) return NumericMatrix(nA, nB);
@@ -1027,6 +1035,7 @@ NumericMatrix cpp_msd_cross_pairs(
     const List& splits_a, const List& splits_b,
     const int n_tip, const int n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int nA = splits_a.size();
   const int nB = splits_b.size();
   if (nA == 0 || nB == 0) return NumericMatrix(nA, nB);
@@ -1070,6 +1079,7 @@ NumericMatrix cpp_msi_cross_pairs(
     const List& splits_a, const List& splits_b,
     const int n_tip, const int n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int nA = splits_a.size();
   const int nB = splits_b.size();
   if (nA == 0 || nB == 0) return NumericMatrix(nA, nB);
@@ -1110,6 +1120,7 @@ NumericMatrix cpp_shared_phylo_cross_pairs(
     const List& splits_a, const List& splits_b,
     const int n_tip, const int n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int nA = splits_a.size();
   const int nB = splits_b.size();
   if (nA == 0 || nB == 0) return NumericMatrix(nA, nB);
@@ -1153,6 +1164,7 @@ NumericMatrix cpp_jaccard_cross_pairs(
     const bool allow_conflict = true,
     const int n_threads = 1
 ) {
+  TreeDist::check_ntip(n_tip);
   const int nA = splits_a.size();
   const int nB = splits_b.size();
   if (nA == 0 || nB == 0) return NumericMatrix(nA, nB);
@@ -1206,6 +1218,7 @@ NumericVector cpp_clustering_entropy_batch(
     const List& splits_list,
     const int   n_tip
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   NumericVector result(N);
   if (N == 0 || n_tip <= 0) return result;
@@ -1239,6 +1252,7 @@ NumericVector cpp_splitwise_info_batch(
     const List& splits_list,
     const int   n_tip
 ) {
+  TreeDist::check_ntip(n_tip);
   const int N = splits_list.size();
   NumericVector result(N);
   if (N == 0 || n_tip < 4) return result;

--- a/src/tree_distances.cpp
+++ b/src/tree_distances.cpp
@@ -28,13 +28,21 @@ namespace TreeDist {
     }
   }
 
-  void check_ntip(const double n) {
-    // Validated by R caller (nTip > 32767 guard in CalculateTreeDistance et al.)
-    ASSERT(n <= static_cast<double>(std::numeric_limits<int16>::max())
-           && "This many tips are not (yet) supported.");
+  void check_ntip(const int32 n) {
+    if (n > SL_MAX_TIPS) {
+      Rcpp::stop("Trees with %d tips exceed the compiled limit of %d. "
+                 "Update TreeTools to support more tips, then reinstall "
+                 "TreeDist.", static_cast<int>(n),
+                 static_cast<int>(SL_MAX_TIPS));
+    }
   }
 
 
+}
+
+// [[Rcpp::export]]
+int cpp_sl_max_tips() {
+  return static_cast<int>(SL_MAX_TIPS);
 }
 
 using TreeDist::resize_uninitialized;
@@ -619,7 +627,9 @@ inline List shared_phylo (const RawMatrix &x, const RawMatrix &y,
 List cpp_robinson_foulds_distance(const RawMatrix &x, const RawMatrix &y,
                                   const IntegerVector &nTip) {
   ASSERT(x.cols() == y.cols() && "Input splits must address same number of tips.");
-  return robinson_foulds_distance(x, y, static_cast<int32>(nTip[0]));
+  const int32 n_tip = static_cast<int32>(nTip[0]);
+  TreeDist::check_ntip(n_tip);
+  return robinson_foulds_distance(x, y, n_tip);
 }
 
 // [[Rcpp::export]]

--- a/src/tree_distances.cpp
+++ b/src/tree_distances.cpp
@@ -62,6 +62,7 @@ inline List robinson_foulds_distance(const RawMatrix &x, const RawMatrix &y,
   }
   
   for (int32 ai = a.n_splits; ai--; ) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     for (int32 bi = b.n_splits; bi--; ) {
       
       bool all_match = true;
@@ -119,6 +120,7 @@ inline List robinson_foulds_info(const RawMatrix &x, const RawMatrix &y,
   }
   
   for (int16 ai = 0; ai < a.n_splits; ++ai) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     for (int16 bi = 0; bi < b.n_splits; ++bi) {
       
       bool all_match = true, all_complement = true;
@@ -173,6 +175,7 @@ inline List matching_split_distance(const RawMatrix &x, const RawMatrix &y,
   cost_matrix score(most_splits);
   
   for (int16 ai = 0; ai < a.n_splits; ++ai) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     for (int16 bi = 0; bi < b.n_splits; ++bi) {
       splitbit total = 0;
       for (int16 bin = 0; bin < a.n_bins; ++bin) {
@@ -232,6 +235,7 @@ inline List jaccard_similarity(const RawMatrix &x, const RawMatrix &y,
   cost_matrix score(most_splits);
   
   for (int16 ai = 0; ai < a.n_splits; ++ai) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     
     const int16 na = a.in_split[ai];
     const int16 nA = n_tips - na;
@@ -338,6 +342,7 @@ List msi_distance(const RawMatrix &x, const RawMatrix &y, const int32 n_tips) {
   splitbit different[SL_MAX_BINS];
   
   for (int16 ai = 0; ai < a.n_splits; ++ai) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     for (int16 bi = 0; bi < b.n_splits; ++bi) {
       int16 
         n_different = 0,
@@ -415,6 +420,7 @@ List mutual_clustering(const RawMatrix &x, const RawMatrix &y,
   std::unique_ptr<int16[]> b_match = std::make_unique<int16[]>(b.n_splits);
   
   for (int16 ai = 0; ai < a.n_splits; ++ai) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     if (a_match[ai]) continue;
     
     const int16 na = a.in_split[ai];
@@ -571,6 +577,7 @@ inline List shared_phylo (const RawMatrix &x, const RawMatrix &y,
   cost_matrix score(most_splits);
   
   for (int16 ai = a.n_splits; ai--; ) {
+    if ((ai & 1023) == 0) Rcpp::checkUserInterrupt();
     for (int16 bi = b.n_splits; bi--; ) {
       const double spi_over = TreeDist::spi_overlap(
         a.state[ai], b.state[bi], n_tips, a.in_split[ai], b.in_split[bi],

--- a/src/tree_distances.cpp
+++ b/src/tree_distances.cpp
@@ -51,12 +51,14 @@ inline List robinson_foulds_distance(const RawMatrix &x, const RawMatrix &y,
   
   grf_match matching(a.n_splits, NA_INTEGER);
   
-  splitbit b_complement[SL_MAX_SPLITS][SL_MAX_BINS];
+  const int32 n_bins = a.n_bins;
+  std::vector<splitbit> b_complement(b.n_splits * n_bins);
   for (int32 i = b.n_splits; i--; ) {
+    splitbit* bc_i = &b_complement[i * n_bins];
     for (int32 bin = last_bin; bin--; ) {
-      b_complement[i][bin] = ~b.state[i][bin];
+      bc_i[bin] = ~b.state[i][bin];
     }
-    b_complement[i][last_bin] = b.state[i][last_bin] ^ unset_mask;
+    bc_i[last_bin] = b.state[i][last_bin] ^ unset_mask;
   }
   
   for (int32 ai = a.n_splits; ai--; ) {
@@ -64,16 +66,17 @@ inline List robinson_foulds_distance(const RawMatrix &x, const RawMatrix &y,
       
       bool all_match = true;
       bool all_complement = true;
+      const splitbit* bc_bi = &b_complement[bi * n_bins];
       
-      for (int32 bin = 0; bin < a.n_bins; ++bin) {
+      for (int32 bin = 0; bin < n_bins; ++bin) {
         if ((a.state[ai][bin] != b.state[bi][bin])) {
           all_match = false;
           break;
         }
       }
       if (!all_match) {
-        for (int32 bin = 0; bin < a.n_bins; ++bin) {
-          if (a.state[ai][bin] != b_complement[bi][bin]) {
+        for (int32 bin = 0; bin < n_bins; ++bin) {
+          if (a.state[ai][bin] != bc_bi[bin]) {
             all_complement = false;
             break;
           }
@@ -105,29 +108,31 @@ inline List robinson_foulds_info(const RawMatrix &x, const RawMatrix &y,
   
   grf_match matching(a.n_splits, NA_INTEGER);
   
-  /* Dynamic allocation 20% faster for 105 tips, but VLA not permitted in C11 */
-  splitbit b_complement[SL_MAX_SPLITS][SL_MAX_BINS]; 
+  const int16 n_bins = a.n_bins;
+  std::vector<splitbit> b_complement(b.n_splits * n_bins);
   for (int16 i = 0; i < b.n_splits; i++) {
+    splitbit* bc_i = &b_complement[i * n_bins];
     for (int16 bin = 0; bin < last_bin; ++bin) {
-      b_complement[i][bin] = ~b.state[i][bin];
+      bc_i[bin] = ~b.state[i][bin];
     }
-    b_complement[i][last_bin] = b.state[i][last_bin] ^ unset_mask;
+    bc_i[last_bin] = b.state[i][last_bin] ^ unset_mask;
   }
   
   for (int16 ai = 0; ai < a.n_splits; ++ai) {
     for (int16 bi = 0; bi < b.n_splits; ++bi) {
       
       bool all_match = true, all_complement = true;
+      const splitbit* bc_bi = &b_complement[bi * n_bins];
       
-      for (int16 bin = 0; bin < a.n_bins; ++bin) {
+      for (int16 bin = 0; bin < n_bins; ++bin) {
         if ((a.state[ai][bin] != b.state[bi][bin])) {
           all_match = false;
           break;
         }
       }
       if (!all_match) {
-        for (int16 bin = 0; bin < a.n_bins; ++bin) {
-          if ((a.state[ai][bin] != b_complement[bi][bin])) {
+        for (int16 bin = 0; bin < n_bins; ++bin) {
+          if ((a.state[ai][bin] != bc_bi[bin])) {
             all_complement = false;
             break;
           }

--- a/src/tree_distances.cpp
+++ b/src/tree_distances.cpp
@@ -31,10 +31,16 @@ namespace TreeDist {
 
   void check_ntip(const int32 n) {
     if (n > SL_MAX_TIPS) {
-      Rcpp::stop("Trees with %d tips exceed the compiled limit of %d. "
-                 "Update TreeTools to support more tips, then reinstall "
-                 "TreeDist.", static_cast<int>(n),
-                 static_cast<int>(SL_MAX_TIPS));
+      if (SL_MAX_TIPS <= 2048) {
+        Rcpp::stop("Trees with %d tips exceed the compiled limit of %d. "
+                     "Update TreeTools to support more tips, then reinstall "
+                     "TreeDist.", static_cast<int>(n),
+                     static_cast<int>(SL_MAX_TIPS));
+      } else {
+        Rcpp::stop("Trees with %d tips are not yet supported (maximum %d). ",
+                   static_cast<int>(n),
+                   static_cast<int>(SL_MAX_TIPS));
+      }
     }
   }
 

--- a/src/tree_distances.h
+++ b/src/tree_distances.h
@@ -18,6 +18,10 @@ constexpr splitbit ALL_ONES = (std::numeric_limits<splitbit>::max)();
 
 namespace TreeDist {
 
+  // Validate that n_tips does not exceed the compiled SL_MAX_TIPS limit.
+  // Defined in tree_distances.cpp; calls Rcpp::stop() on failure.
+  void check_ntip(int32 n);
+
   // Re-exported from mutual_clustering.h:
   //   ic_matching(int16 a, int16 b, int16 n)
 

--- a/src/tree_distances.h
+++ b/src/tree_distances.h
@@ -39,7 +39,8 @@ namespace TreeDist {
 
   // Returns lg2_unrooted[x] - lg2_trees_matching_split(y, x - y)
   [[nodiscard]] inline double mmsi_pair_score(const int16 x, const int16 y) noexcept {
-    assert(SL_MAX_TIPS + 2 <= std::numeric_limits<int16>::max()); // verify int16 ok
+    static_assert(SL_MAX_TIPS + 2 <= std::numeric_limits<int16>::max(),
+                  "int16 too narrow for SL_MAX_TIPS");
     
     return lg2_unrooted[x] - (lg2_rooted[y] + lg2_rooted[x - y]);
   }
@@ -60,7 +61,8 @@ namespace TreeDist {
 
 
 [[nodiscard]] inline double one_overlap(const int16 a, const int16 b, const int16 n) noexcept {
-    assert(SL_MAX_TIPS + 2 <= std::numeric_limits<int16>::max()); // verify int16 ok
+    static_assert(SL_MAX_TIPS + 2 <= std::numeric_limits<int16>::max(),
+                  "int16 too narrow for SL_MAX_TIPS");
     if (a == b) {
       return lg2_rooted[a] + lg2_rooted[n - a];
     }
@@ -71,7 +73,8 @@ namespace TreeDist {
   }
   
   [[nodiscard]] inline double one_overlap_notb(const int16 a, const int16 n_minus_b, const int16 n) noexcept {
-    assert(SL_MAX_TIPS + 2 <= std::numeric_limits<int16>::max()); // verify int16 ok
+    static_assert(SL_MAX_TIPS + 2 <= std::numeric_limits<int16>::max(),
+                  "int16 too narrow for SL_MAX_TIPS");
     const int16 b = n - n_minus_b;
     if (a == b) {
       return lg2_rooted[b] + lg2_rooted[n_minus_b];
@@ -90,7 +93,8 @@ namespace TreeDist {
                        const int16 n_tips, const int16 in_a,
                        const int16 in_b, const int16 n_bins) noexcept {
 
-    assert(SL_MAX_BINS <= INT16_MAX);
+    static_assert(SL_MAX_BINS <= INT16_MAX,
+                  "int16 too narrow for SL_MAX_BINS");
 
     int16 n_ab = 0;
     for (int16 bin = 0; bin < n_bins; ++bin) {

--- a/tests/testthat/test-ntip-limit.R
+++ b/tests/testthat/test-ntip-limit.R
@@ -1,0 +1,24 @@
+test_that(".SL_MAX_TIPS is populated", {
+  expect_true(is.integer(TreeDist:::.SL_MAX_TIPS))
+  expect_true(TreeDist:::.SL_MAX_TIPS >= 2048L)
+})
+
+test_that("Trees exceeding SL_MAX_TIPS are rejected", {
+  limit <- TreeDist:::.SL_MAX_TIPS
+  # Build a mock Splits raw matrix with limit + 1 tips.
+  # The matrix needs: nrow = limit - 2 splits, ncol = ceil((limit + 1) / 8)
+  bad_nTip <- limit + 1L
+  n_splits <- bad_nTip - 3L
+  n_cols <- ceiling(bad_nTip / 8)
+  mock <- matrix(as.raw(0), nrow = n_splits, ncol = n_cols)
+  class(mock) <- c("Splits", class(mock))
+  attr(mock, "nTip") <- bad_nTip
+  attr(mock, "tip.label") <- paste0("t", seq_len(bad_nTip))
+
+  expect_error(
+    TreeDist:::GeneralizedRF(mock, mock, bad_nTip,
+                             TreeDist:::cpp_robinson_foulds_distance,
+                             maximize = FALSE, reportMatching = FALSE),
+    "exceed"
+  )
+})

--- a/tests/testthat/test-tree_distance_utilities.R
+++ b/tests/testthat/test-tree_distance_utilities.R
@@ -32,17 +32,15 @@ test_that("CalculateTreeDistance() errs appropriately", {
 })
 
 test_that("Tip-count guard is applied consistently", {
-  expect_no_error(.AssertNtipSupported(1000L))
-  expect_no_error(.AssertNtipSupported(32766L))
-  expect_no_error(.AssertNtipSupported(32767L))
-  expect_error(.AssertNtipSupported(32768L),
-               "This many tips are not \\(yet\\) supported\\.")
-
   errMsg <- if (packageVersion("TreeTools") >= "2.2.0.9002") {
-    "This many tips are not \\(yet\\) supported\\."
+    "Trees with 327.. tips are not yet supported \\(maximum 32704\\)"
   } else {
-    "Trees with 32768 tips exceed the compiled limit of 2048"
+    "Trees with 327.. tips exceed the compiled limit of 2048"
   }
+
+  expect_no_error(.CheckMaxTips(1000L))
+  expect_no_error(.CheckMaxTips(32704L))
+  expect_error(.CheckMaxTips(32705L), errMsg)
   splits8 <- unclass(as.Splits(BalancedTree(8)))
   expect_error(cpp_robinson_foulds_distance(splits8, splits8, 32768L),
                errMsg)

--- a/tests/testthat/test-tree_distance_utilities.R
+++ b/tests/testthat/test-tree_distance_utilities.R
@@ -38,17 +38,22 @@ test_that("Tip-count guard is applied consistently", {
   expect_error(.AssertNtipSupported(32768L),
                "This many tips are not \\(yet\\) supported\\.")
 
+  errMsg <- if (packageVersion("TreeTools") >= "2.2.0.9002") {
+    "This many tips are not \\(yet\\) supported\\."
+  } else {
+    "Trees with 32768 tips exceed the compiled limit of 2048"
+  }
   splits8 <- unclass(as.Splits(BalancedTree(8)))
   expect_error(cpp_robinson_foulds_distance(splits8, splits8, 32768L),
-               "This many tips are not \\(yet\\) supported\\.")
+               errMsg)
   expect_error(cpp_robinson_foulds_info(splits8, splits8, 32768L),
-               "This many tips are not \\(yet\\) supported\\.")
+               errMsg)
 
   trees <- list(BalancedTree(8), PectinateTree(8))
   class(trees) <- "multiPhylo"
   expect_error(
     .SplitDistanceAllPairs(RobinsonFouldsSplits, trees, letters[1:8], 32768L),
-    "This many tips are not \\(yet\\) supported\\."
+    errMsg
   )
 })
 

--- a/tests/testthat/test-tree_distance_utilities.R
+++ b/tests/testthat/test-tree_distance_utilities.R
@@ -32,15 +32,18 @@ test_that("CalculateTreeDistance() errs appropriately", {
 })
 
 test_that("Tip-count guard is applied consistently", {
-  errMsg <- if (packageVersion("TreeTools") >= "2.2.0.9002") {
+  expect_no_error(.CheckMaxTips(1000L))
+  
+  limit32704 <- packageVersion("TreeTools") >= "2.2.0.9002"
+  if (limit32704) expect_no_error(.CheckMaxTips(32704L))
+  
+  errMsg <- if (limit32704) {
     "Trees with 327.. tips are not yet supported \\(maximum 32704\\)"
   } else {
     "Trees with 327.. tips exceed the compiled limit of 2048"
   }
-
-  expect_no_error(.CheckMaxTips(1000L))
-  expect_no_error(.CheckMaxTips(32704L))
   expect_error(.CheckMaxTips(32705L), errMsg)
+  
   splits8 <- unclass(as.Splits(BalancedTree(8)))
   expect_error(cpp_robinson_foulds_distance(splits8, splits8, 32768L),
                errMsg)


### PR DESCRIPTION
…port

The two splitbit b_complement[SL_MAX_SPLITS][SL_MAX_BINS] stack arrays in robinson_foulds_distance() and robinson_foulds_info() would overflow the stack when compiled against TreeTools with SL_MAX_TIPS = 32768 (128 GB).

Replace with std::vector<splitbit> sized to actual dimensions (b.n_splits * n_bins).  These are serial per-pair paths (reportMatching = TRUE), so heap allocation cost is negligible.

Also upgrade assert() to static_assert() in tree_distances.h for the int16 width checks — these now fire at compile time rather than silently passing in release builds.