### PR TITLE
ci: fix revdepcheck 'subscript out of bounds' from empty deps

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -218,13 +218,11 @@ jobs:
       R_COMPILE_AND_INSTALL_PACKAGES: 'never'
       R_REMOTES_STANDALONE: true
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      
+
     steps:
       - uses: ms609/actions/revdepcheck@main
         with:
-          deps: ${{ matrix.config.deps }}
           extra-packages: ms609/TreeDistData
 
   benchmark:

--- a/.github/workflows/revdepcheck.yml
+++ b/.github/workflows/revdepcheck.yml
@@ -14,11 +14,9 @@ jobs:
       R_COMPILE_AND_INSTALL_PACKAGES: 'never'
       R_REMOTES_STANDALONE: true
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: ms609/actions/revdepcheck@main
         with:
-          deps: ${{ matrix.config.deps }}
           extra-packages: ms609/TreeDistData


### PR DESCRIPTION
## Root cause

The `rev-dep-check` job passes `deps: ${{ matrix.config.deps }}`, but the job has **no `strategy.matrix`** — so the expression evaluates to an empty string and overrides the action's default.

The June-5 rewrite of `ms609/actions/revdepcheck` moved the deps interpolation onto a standalone line, `deps <- ${{ inputs.deps }}`. With empty input this renders a bare `deps <- ` that swallows the next statement:

```r
deps <-
pkg <- read.dcf("DESCRIPTION", fields = "Package")[1, 1]
# parses as:  deps <- pkg <- read.dcf(...)[1, 1]   ->  deps == "TreeDist"
```

`which = "TreeDist"` then makes `tools::package_dependencies()` do `db[ind, c("Package", "TreeDist"), drop = FALSE]` → **subscript out of bounds**. (Confirmed by local repro; it is *not* an R 4.6.0 `available.packages()` class change — that still returns a plain matrix.)

Previously the action interpolated deps inline as a function argument (`dependencies = ${{ inputs.deps }})`), where empty rendered `dependencies = )` — valid R that passes the argument as *missing*, silently using the default. The move to a standalone assignment is what made empty fatal.

## Fix

- **This PR (caller):** drop the dangling `matrix.config.deps` / `matrix.config.rspm` refs in both revdepcheck jobs so the action's defaults apply.
- **Already merged (action, load-bearing):** [ms609/actions@633b510](https://github.com/ms609/actions/commit/633b510be377a1a03ac2dde8ef9fa0553dc5efd8) reads deps via `INPUT_DEPS` with a fallback default, so an empty input can never swallow a line again — protecting all consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)