### PR TITLE
Collapse superseded benchmark comments rather than prefixing them

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -330,29 +330,58 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const benchmarkIdentifier = '<!-- benchmark-comment -->';
-            const outdatedPrefix = '> **⚠️ This benchmark result is outdated. See the latest comment below.**\n\n';
 
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-
-            const previousBenchmarkComments = comments.data.filter(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes(benchmarkIdentifier) &&
-              !comment.body.startsWith('> **⚠️ This benchmark result is outdated.')
-            );
-
-            for (const comment of previousBenchmarkComments) {
-              await github.rest.issues.updateComment({
+            // Nothing below may throw: this step exists to post the new result,
+            // and losing that to a hiccup in the tidy-up of the old ones would
+            // be a poor trade. Both halves warn instead.
+            let previousBenchmarkComments = [];
+            try {
+              // The listing has to come from GraphQL: REST's comment payload
+              // omits isMinimized, so it cannot tell a comment this step has
+              // already collapsed from a live one, and each run would re-
+              // minimize the whole history.
+              const { repository } = await github.graphql(`
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      comments(last: 100) {
+                        nodes { id body isMinimized author { __typename } }
+                      }
+                    }
+                  }
+                }`, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                comment_id: comment.id,
-                body: outdatedPrefix + comment.body
+                number: context.issue.number
               });
+              previousBenchmarkComments =
+                repository.pullRequest.comments.nodes.filter(comment =>
+                  comment.author?.__typename === 'Bot' &&
+                  comment.body.includes(benchmarkIdentifier) &&
+                  !comment.isMinimized
+                );
+            } catch (error) {
+              core.warning(`Could not list benchmark comments: ${error.message}`);
             }
 
+            // Collapse each as outdated. The likeliest failure is a token
+            // without the scope minimizeComment needs.
+            for (const comment of previousBenchmarkComments) {
+              try {
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      minimizedComment { isMinimized }
+                    }
+                  }`, { id: comment.id });
+              } catch (error) {
+                core.warning(
+                  `Could not collapse benchmark comment ${comment.id}: ${error.message}`
+                );
+              }
+            }
+
+            // Create new comment with identifier
             const newCommentBody = benchmarkIdentifier + '\n' + process.env.BENCHMARK_MESSAGE;
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
GitHub can genuinely collapse a superseded comment — `minimizeComment` with
`classifier: OUTDATED` — rather than leaving it at full height behind a `⚠️`
banner. The benchmark comment step now does that.

### What changed

- The listing moves from `issues.listComments` to GraphQL, because REST's
  comment payload omits `isMinimized`. Minimizing no longer edits the body, so
  that flag is the only remaining idempotency guard; without it every run would
  re-minimize the entire history.
- The listing and each mutation warn rather than throw. This step exists to post
  the new result, and losing that to a hiccup while tidying up the old ones
  would be a poor trade.

### Worth knowing

- Comments already carrying the old `⚠️` banner keep it, and are not minimized,
  so the first run under this code collapses them banner and all — one slightly
  ugly comment per open PR, then it is clean.
- Fork PRs still get a read-only token and the whole step no-ops there, exactly
  as before.
- This job declares no `permissions:` block, so its token comes from the
  repository default. `minimizeComment` needs write access to the comment; if
  the default proves too narrow, the run log says so and the benchmark comment
  still posts.

No `NEWS.md` / `DESCRIPTION` bump: CI plumbing is not user-visible package
behaviour.

Companion PRs apply the same change to the other repos carrying this script
(`ms609/Coreset`, `ms609/TreeTools`, `ms609/TreeDist`). `TreeSearch`'s
`agent-benchmark.yml` is dispatch-only and uploads artifacts without commenting,
so it needs nothing.

---

Agent work, filed under @ms609's own account because the `ms609-agent` account
is currently suspended — so it has *not* had the independent review that
agent-authored PRs normally get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
